### PR TITLE
Add endpoint for serving available voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,42 @@ python audio_reader.py -s 2 < LICENSE # read the software license - fast
 * [OpenAI Text to speech guide](https://platform.openai.com/docs/guides/text-to-speech)
 * [OpenAI API Reference](https://platform.openai.com/docs/api-reference/audio/createSpeech)
 
+## Available Voices Endpoint
+
+The `/v1/voices` endpoint allows you to retrieve the available voices and TTS models. This endpoint reads the `config/voice_to_speaker.yaml` file and returns the available voices and TTS models in JSON format.
+
+### Example Request
+
+```shell
+curl http://localhost:8000/v1/voices
+```
+
+### Example Response
+
+```json
+{
+  "tts-1": {
+    "alloy": {
+      "model": "voices/en_US-alloy.onnx",
+      "language": "en"
+    },
+    "echo": {
+      "model": "voices/en_US-echo.onnx",
+      "language": "en"
+    }
+  },
+  "tts-1-hd": {
+    "alloy": {
+      "model": "xtts",
+      "language": "en"
+    },
+    "echo": {
+      "model": "xtts",
+      "language": "en"
+    }
+  }
+}
+```
 
 ## Custom Voices Howto
 

--- a/config/voice_to_speaker.yaml
+++ b/config/voice_to_speaker.yaml
@@ -1,0 +1,59 @@
+tts-1:
+  some_other_voice_name_you_want:
+    model: voices/choose your own model
+    speaker: set your own speaker
+  alloy:
+    model: voices/en_US-libritts_r-medium
+    speaker: 79 # 64, 79, 80, 101, 130
+  echo:
+    model: voices/en_US-libritts_r-medium
+    speaker: 134 # 52, 102, 134
+  echo-alt:
+    model: voices/en_US-ryan-high
+    speaker: # default speaker
+  fable:
+    model: voices/en_GB-northern_english_male-medium
+    speaker: # default speaker
+  onyx:
+    model: voices/en_US-libritts_r-medium
+    speaker: 159 # 55, 90, 132, 136, 137, 159
+  nova:
+    model: voices/en_US-libritts_r-medium
+    speaker: 107 # 57, 61, 107, 150, 162
+  shimmer:
+    model: voices/en_US-libritts_r-medium
+    speaker: 163
+tts-1-hd:
+  alloy-alt:
+    model: xtts
+    speaker: voices/alloy-alt.wav
+  alloy:
+    model: xtts
+    speaker: voices/alloy.wav
+  echo:
+    model: xtts
+    speaker: voices/echo.wav
+  fable:
+    model: xtts
+    speaker: voices/fable.wav
+  onyx:
+    model: xtts
+    speaker: voices/onyx.wav
+  nova:
+    model: xtts
+    speaker: voices/nova.wav
+  shimmer:
+    model: xtts
+    speaker: voices/shimmer.wav
+  me:
+    model: xtts_v2.0.2 # you can specify an older xtts version
+    speaker: voices/me.wav # this could be you
+    language: auto
+    enable_text_splitting: True
+    length_penalty: 1.0
+    repetition_penalty: 10
+    speed: 1.0
+    temperature: 0.75
+    top_k: 50
+    top_p: 0.85
+    comment: You can add a comment here also, which will be persistent and otherwise ignored.

--- a/openedai.py
+++ b/openedai.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse, JSONResponse
 from loguru import logger
+import yaml
 
 class OpenAIError(Exception):
     pass
@@ -152,6 +153,15 @@ class OpenAIStub(FastAPI):
         @self.get("/v1/models/{model}")
         async def get_model_info(model_id: str):
             return self.model_info(model_id)
+
+        @self.get("/v1/voices")
+        async def get_voices():
+            try:
+                with open('config/voice_to_speaker.yaml', 'r', encoding='utf8') as file:
+                    voice_map = yaml.safe_load(file)
+                return voice_map
+            except Exception as e:
+                raise InternalServerError(f"Error reading voice_to_speaker.yaml: {str(e)}")
 
     def register_model(self, name: str, model: str = None) -> None:
         self.models[name] = model if model else name


### PR DESCRIPTION
Add an endpoint for serving available voices and TTS models.

* Add a new endpoint `/v1/voices` in `openedai.py` to serve available voices and TTS models.
* Read the `config/voice_to_speaker.yaml` file in the new endpoint and return the available voices and TTS models in JSON format.
* Update `README.md` to include documentation for the new `/v1/voices` endpoint.
* Add `config/voice_to_speaker.yaml` file with the mapping of voices to models.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Wladastic/openedai-speech-api-fixed/pull/1?shareId=eafea9ae-bc63-4141-b82f-3534bcf5895f).