### PR TITLE
Fix API endpoints for voices and models

### DIFF
--- a/openedai.py
+++ b/openedai.py
@@ -146,15 +146,15 @@ class OpenAIStub(FastAPI):
         async def health():
             return {"status": "ok" if self.models else "unk" }
 
-        @self.get("/v1/models")
+        @self.get("/v1/audio/models")
         async def get_model_list():
             return self.model_list()
 
-        @self.get("/v1/models/{model}")
+        @self.get("/v1/audio/models/{model}")
         async def get_model_info(model_id: str):
             return self.model_info(model_id)
 
-        @self.get("/v1/voices")
+        @self.get("/v1/audio/voices")
         async def get_voices():
             try:
                 with open('config/voice_to_speaker.yaml', 'r', encoding='utf8') as file:


### PR DESCRIPTION
For some reason the speech.py was using the correct endpoint format for post speech but get voices and models is expected to contain /audio/ in the url as well.
Otherwise not working:
INFO:     172.19.0.1:56756 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     172.19.0.1:56766 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     172.19.0.1:57874 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     172.19.0.1:57890 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     172.19.0.1:55500 - "GET /v1/audio/voices HTTP/1.1" 404 Not Found
INFO:     172.19.0.1:55502 - "GET /v1/audio/models HTTP/1.1" 404 Not Found
INFO:     172.19.0.1:64692 - "GET /v1/audio/voices HTTP/1.1" 404 Not Found
INFO:     172.19.0.1:64704 - "GET /v1/audio/models HTTP/1.1" 404 Not Found
INFO:     172.19.0.1:58402 - "GET /v1/audio/voices HTTP/1.1" 404 Not Found
